### PR TITLE
[LIVY-868] ACL on livy session listing

### DIFF
--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -72,7 +72,10 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
     val from = params.get("from").map(_.toInt).getOrElse(0)
     val size = params.get("size").map(_.toInt).getOrElse(100)
 
-    val sessions = sessionManager.all()
+    val sessions = sessionManager.all().filter(
+      session => accessManager.hasViewAccess(session.owner,
+        effectiveUser(request), session.proxyUser.getOrElse(""))
+    )
 
     Map(
       "from" -> from,


### PR DESCRIPTION
Checks if requester is session owner or has rights to view session before returning the session.

## What changes were proposed in this pull request?
Filter sessions listing (in get('/")) returned by SessionServlet based on ownership and access granted.

https://issues.apache.org/jira/browse/LIVY-868

## How was this patch tested?
Changes tested manually in kerberized environment. 
Only able to see own sessions in UI page unless view and able permission granted.
